### PR TITLE
Improve Windows setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Setup libsecp256k1'
-description: 'Installs libsecp256k1'
+name: 'Setup Haskell toolchain versions'
+description: 'Setup Haskell toolchain versions'
 inputs:
   ghc-version:
     description: Version of GHC to install
@@ -9,10 +9,6 @@ inputs:
     description: Version of cabal to install
     default: ''
 
-  pacman-packages:
-    description: Pacman packages to install
-    default: ''
-
 outputs:
   cabal-store:
     description: "Prefix"
@@ -20,85 +16,17 @@ outputs:
 
 runs:
   using: "composite"
+
   steps:
-    - name: "Install pkg-config"
-      if: runner.os == 'macOS'
-      shell: bash
-      run: brew install pkg-config
-
-    - name: Setup PKG_CONFIG_PATH
-      shell: bash
-      run: |
-        if [ ${{ runner.os }} == "macOS" ]; then
-          # OpenSSL is installed in a non-standard location in MacOS. See
-          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
-          echo "PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig" | tee -a "$GITHUB_ENV"
-        elif [ ${{ runner.os }} == "Linux" ]; then
-          echo "PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/local/lib/pkgconfig" | tee -a "$GITHUB_ENV"
-        fi
-
-    - name: Setup LD_LIBRARY_PATH
-      shell: bash
-      run: |
-        if [ ${{ runner.os }} != "Windows" ]; then
-          # OpenSSL is installed in a non-standard location in MacOS. See
-          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
-          echo "LD_LIBRARY_PATH=/usr/local/lib" | tee -a "$GITHUB_ENV"
-        fi
-
-    # For some unknown reason, the pacman setup must come before ghc installation.
-    # It appears as if PATHEXT is set _after_ ghcup install ghc/cabal, and
-    # as such we'd need pacman.exe instead.
-    - name: "WIN: Install System Dependencies via pacman (msys2)"
-      if: runner.os == 'Windows' && inputs.pacman-packages != ''
-      shell: pwsh
-      run: |
-         # ghcup should be installed on current GHA Windows runners. Let's use ghcup to run
-         # pacman, to install the necessary dependencies, ...
-         ghcup run -- pacman --noconfirm -S ${{ inputs.pacman-packages }}
-
-    - name: Setup GHC (Windows)
-      if: inputs.ghc-version != '' && runner.os == 'Windows'
-      shell: pwsh
-      run: ghcup install ghc --set ${{ inputs.ghc-version }}
-
-    - name: Setup GHC (Posix)
+    - name: Setup GHC
       if: inputs.ghc-version != ''
       shell: bash
       run: ghcup install ghc --set ${{ inputs.ghc-version }}
 
-    - name: Setup cabal (Windows)
-      if: inputs.cabal-version != '' && runner.os == 'Windows'
-      shell: pwsh
-      run: ghcup install cabal --set ${{ inputs.cabal-version }}
-
-    - name: Setup cabal (Posix)
+    - name: Setup cabal
       if: inputs.cabal-version != ''
       shell: bash
       run: ghcup install cabal --set ${{ inputs.cabal-version }}
-
-    - name: "WIN: fixup cabal config"
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        # make sure cabal knows about msys64, and mingw64 tools. Not clear why C:/cabal/config is empty
-        # and C:/cabal doesn't even exist.  The ghcup bootstrap file should have create it in the image:
-        # See https://github.com/haskell/ghcup-hs/blob/787edc17af4907dbc51c85e25c490edd8d68b80b/scripts/bootstrap/bootstrap-haskell#L591
-        # So we'll do it by hand here for now.
-        #
-        # We'll _not_ add extra-include-dirs, or extra-lib-dirs, and rely on what's shipped with GHC.
-        # https://github.com/msys2/MINGW-packages/issues/10837#issuecomment-1047105402
-        # https://gitlab.haskell.org/ghc/ghc/-/issues/21111
-        # if we _do_ want them, this would be the lines to add below
-
-        $ghcMingwDir = Join-Path -Path $(ghc --print-libdir) `
-                                 -ChildPath ../mingw/x86_64-*-mingw32/lib/ `
-                                 -Resolve
-
-        cabal user-config -a "extra-prog-path: C:/msys64/mingw64/bin, C:/msys64/usr/bin" `
-                          -a "extra-include-dirs: C:/msys64/mingw64/include" `
-                          -a ("extra-lib-dirs: {0}, C:/msys64/mingw64/lib" -f $ghcMingwDir) `
-                          -f init
 
     # Unify the computation of the cabal store directory to a single step. This makes referencing the cabal
     # store in later steps easier.

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Version of cabal to install
     default: ''
 
+  pacman-packages:
+    description: Pacman packages to install
+    default: ''
+
 outputs:
   cabal-store:
     description: "Prefix"
@@ -27,6 +31,14 @@ runs:
       if: inputs.cabal-version != ''
       shell: bash
       run: ghcup install cabal --set ${{ inputs.cabal-version }}
+
+    - name: "WIN: Install System Dependencies via pacman (msys2)"
+      if: runner.os == 'Windows' && inputs.pacman-packages != ''
+      shell: 'C:/msys64/usr/bin/bash.exe -e {0}'
+      run: |
+         printf "::warning::pacman packages will be installed via the input-output-hk/actions/haskell workflow.\nHowever there is no need to do it here and in general it is better to just do it on your workflow using \`/usr/bin/pacman -S -noconfirm %s\`.\nWe might remove this feature soon so please do as advised.\n\nA full step you can copy-paste into your workflow would look as follows:\n\`\`\`\n    - name: \"WIN: Install System Dependencies via pacman (msys2)\"\n      if: runner.os == 'Windows'\n      shell: 'C:/msys64/usr/bin/bash.exe -e {0}'\n      run: |\n        /usr/bin/pacman -S -noconfirm %s\n\`\`\`\n" "$(echo "${{ inputs.pacman-packages }}" | head -c -1)" "$(echo "${{ inputs.pacman-packages }}" | head -c -1)"
+         /usr/bin/pacman --noconfirm -S ${{ inputs.pacman-packages }}
+
 
     # Unify the computation of the cabal store directory to a single step. This makes referencing the cabal
     # store in later steps easier.


### PR DESCRIPTION
- Install a sensible `pkg-config` by default. Suitable for the Haskell toolchain. See the comments.
- Remove the fixup of the config. With a suitable `pkg-config` they are not needed.
- Remove the input for pacman packages. They can be installed afterwards by the user.